### PR TITLE
HighchartsModuleLoaded event

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "highcharts-assembler",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "The official bundler for Highcharts JS.",
   "main": "index.js",
   "directories": {

--- a/src/templates/umd-module.txt
+++ b/src/templates/umd-module.txt
@@ -15,6 +15,15 @@
     function _registerModule(obj, path, args, fn) {
         if (!obj.hasOwnProperty(path)) {
             obj[path] = fn.apply(null, args);
+
+            if (typeof CustomEvent === 'function') {
+                window.dispatchEvent(
+                    new CustomEvent(
+                        'HighchartsModuleLoaded',
+                        { detail: { path: path, module: obj[path] }
+                    })
+                );
+            }
         }
     }
 @content

--- a/src/templates/umd-standalone.txt
+++ b/src/templates/umd-standalone.txt
@@ -20,6 +20,17 @@
     function _registerModule(obj, path, args, fn) {
         if (!obj.hasOwnProperty(path)) {
             obj[path] = fn.apply(null, args);
+
+            // Trigger module load event. Don't bloat it with support IE11 out
+            // of the box. If needed, a polyfill for CustomEvent should do it.
+            if (typeof CustomEvent === 'function') {
+                window.dispatchEvent(
+                    new CustomEvent(
+                        'HighchartsModuleLoaded',
+                        { detail: { path: path, module: obj[path] }
+                    })
+                );
+            }
         }
     }
 @content

--- a/src/templates/umd-standalone.txt
+++ b/src/templates/umd-standalone.txt
@@ -21,8 +21,6 @@
         if (!obj.hasOwnProperty(path)) {
             obj[path] = fn.apply(null, args);
 
-            // Trigger module load event. Don't bloat it with support IE11 out
-            // of the box. If needed, a polyfill for CustomEvent should do it.
             if (typeof CustomEvent === 'function') {
                 window.dispatchEvent(
                     new CustomEvent(


### PR DESCRIPTION
This will allow us (the devs and support team) to inject modifications and hotfixes into module members before they are stored as local variables in subsequent modules.

### Usage
```html

<script>
/* Optional: IE polyfill
if (typeof CustomEvent !== 'function') {
    function CustomEvent(event, params) {
        params = params || { bubbles: false, cancelable: false, detail: undefined }
        var evt = document.createEvent("CustomEvent")
        evt.initCustomEvent(event, params.bubbles, params.cancelable, params.detail)
        return evt
    }
    CustomEvent.prototype = window.Event.prototype;
    window.CustomEvent = CustomEvent;
}
*/

// This event is attached to the window object before loading Highcharts, and
// will fire immediately after loading each module. Thus allowing mutation of
// members before they are loaded into subsequent modules.
window.addEventListener('HighchartsModuleLoaded', function(e) {
    console.log(e.detail.path)
    if (e.detail.path === 'Core/FormatUtilities.js') {
        const numberFormat = e.detail.module.numberFormat;

        // A stupid proof of concept - negate all formatted numbers
        e.detail.module.numberFormat = function () {
            const n = numberFormat.apply(this, arguments);
            return '-' + n;
        }
    }
});
</script>
<script src="https://code.highcharts.com/highcharts.js"></script>
<script src="https://code.highcharts.com/modules/exporting.js"></script>

<div id="container"></div>
```