### PR TITLE
Added support for highcharts.css with CSS variables

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "highcharts-assembler",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "The official bundler for Highcharts JS.",
   "main": "index.js",
   "directories": {

--- a/src/build.js
+++ b/src/build.js
@@ -232,7 +232,7 @@ const buildModules = userOptions => {
           (
             isString(options.pathPalette)
               ? options.pathPalette
-              : options.base + '../css/highcharts.scss'
+              : options.base + '../css/highcharts.css'
           )
         )
     }


### PR DESCRIPTION
With Highcharts v11 the palette is defined as CSS variables in `highcharts.css`. Legacy `highcharts.scss` support is retained for testing against older stages of the code.