### PR TITLE
v1.5.2: Added support for @moduleSpace to product namespace replacement.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@highcharts/highcharts-assembler",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@highcharts/highcharts-assembler",
-      "version": "1.5.1",
+      "version": "1.5.2",
       "license": "ISC",
       "devDependencies": {
         "chai": "^4.3.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@highcharts/highcharts-assembler",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "The official bundler for Highcharts JS.",
   "main": "index.js",
   "directories": {

--- a/src/build.js
+++ b/src/build.js
@@ -96,6 +96,7 @@ const getIndividualOptions = ({
   exclude,
   files,
   fileOptions = {},
+  namespace,
   output,
   palette,
   product,
@@ -117,6 +118,7 @@ const getIndividualOptions = ({
       date,
       entry: resolve(join(base, filename)),
       exclude,
+      namespace,
       product,
       umd,
       version
@@ -136,7 +138,7 @@ const getIndividualOptions = ({
 }
 
 const getESModuleOptions = (
-  { base, date, output, files, palette, product, types, version }
+  { base, date, output, files, namespace, palette, product, types, version }
 ) => {
   const process = getProcess(palette)
   return files.reduce((arr, filename, i) => {
@@ -145,6 +147,7 @@ const getESModuleOptions = (
       date,
       process: process[type],
       entry,
+      namespace,
       outputPath: resolve(join(
         output,
         (type === 'classic' ? '' : 'js/'),

--- a/src/dependencies.js
+++ b/src/dependencies.js
@@ -535,18 +535,18 @@ const moduleTransform = (content, options) => {
  * @returns {string}         Content of file after transformation
  */
 const fileTransform = (content, options) => {
-  const { entry, moduleName, printPath, product, requires, umd } = options
+  const { entry, moduleName, namespace, printPath, requires, umd } = options
   let result = umd ? applyUMD(content, printPath) : applyModule(content)
   result = addLicenseHeader(result, { entry })
   return result
-    .replace('@moduleEvent', `'${product}ModuleLoaded'`)
+    .replace('@moduleEvent', `'${namespace}ModuleLoaded'`)
     .replace('@moduleName', moduleName ? `'${moduleName}', ` : '')
-    .replace('@AMDParams', requires.length ? product : '')
+    .replace('@AMDParams', requires.length ? namespace : '')
     .replace('@AMDFactory', requires.length
-      ? '\n' + indent(`factory(${product});\nfactory.${product} = ${product};`, IND.repeat(3))
+      ? '\n' + indent(`factory(${namespace});\nfactory.${namespace} = ${namespace};`, IND.repeat(3))
       : ''
     )
-    .replace(/@name/g, product)
+    .replace(/@name/g, namespace)
     .replace(/@dependencies/g, safeReplace(requires.join('\', \'')))
 }
 
@@ -562,9 +562,9 @@ const compileFile = options => {
   const {
     requires = getRequires(contentEntry),
     exclude = getExcludedFilenames(requires, base),
-    umd = requires.length === 0,
     moduleName = getModuleName(contentEntry),
-    product = 'Highcharts'
+    namespace = 'Highcharts',
+    umd = requires.length === 0
   } = options
 
   // Transform modules
@@ -588,7 +588,7 @@ const compileFile = options => {
   const printPath = relative(join(base, '../'), entry).split('\\').join('/')
   return fileTransform(
     modules,
-    { entry, moduleName, printPath, product, requires, umd }
+    { entry, moduleName, namespace, printPath, requires, umd }
   )
 }
 

--- a/src/dependencies.js
+++ b/src/dependencies.js
@@ -546,8 +546,8 @@ const fileTransform = (content, options) => {
       ? '\n' + indent(`factory(${namespace});\nfactory.${namespace} = ${namespace};`, IND.repeat(3))
       : ''
     )
-    .replace(/@name/g, namespace)
     .replace(/@dependencies/g, safeReplace(requires.join('\', \'')))
+    .replace(/@moduleSpace/g, namespace)
 }
 
 const compileFile = options => {

--- a/src/templates/umd-module.txt
+++ b/src/templates/umd-module.txt
@@ -7,11 +7,11 @@
             return factory;
         });
     } else {
-        factory(typeof @name !== 'undefined' ? @name : undefined);
+        factory(typeof @moduleSpace !== 'undefined' ? @moduleSpace : undefined);
     }
-}(function (@name) {
+}(function (@moduleSpace) {
     'use strict';
-    var _modules = @name ? @name._modules : {};
+    var _modules = @moduleSpace ? @moduleSpace._modules : {};
     function _registerModule(obj, path, args, fn) {
         if (!obj.hasOwnProperty(path)) {
             obj[path] = fn.apply(null, args);

--- a/src/templates/umd-module.txt
+++ b/src/templates/umd-module.txt
@@ -17,12 +17,10 @@
             obj[path] = fn.apply(null, args);
 
             if (typeof CustomEvent === 'function') {
-                window.dispatchEvent(
-                    new CustomEvent(
-                        @moduleEvent,
-                        { detail: { path: path, module: obj[path] }
-                    })
-                );
+                window.dispatchEvent(new CustomEvent(
+                    @moduleEvent,
+                    { detail: { path: path, module: obj[path] } }
+                ));
             }
         }
     }

--- a/src/templates/umd-module.txt
+++ b/src/templates/umd-module.txt
@@ -7,11 +7,11 @@
             return factory;
         });
     } else {
-        factory(typeof Highcharts !== 'undefined' ? Highcharts : undefined);
+        factory(typeof @name !== 'undefined' ? @name : undefined);
     }
-}(function (Highcharts) {
+}(function (@name) {
     'use strict';
-    var _modules = Highcharts ? Highcharts._modules : {};
+    var _modules = @name ? @name._modules : {};
     function _registerModule(obj, path, args, fn) {
         if (!obj.hasOwnProperty(path)) {
             obj[path] = fn.apply(null, args);
@@ -19,7 +19,7 @@
             if (typeof CustomEvent === 'function') {
                 window.dispatchEvent(
                     new CustomEvent(
-                        'HighchartsModuleLoaded',
+                        @moduleEvent,
                         { detail: { path: path, module: obj[path] }
                     })
                 );

--- a/src/templates/umd-standalone.txt
+++ b/src/templates/umd-standalone.txt
@@ -22,12 +22,10 @@
             obj[path] = fn.apply(null, args);
 
             if (typeof CustomEvent === 'function') {
-                window.dispatchEvent(
-                    new CustomEvent(
-                        @moduleEvent,
-                        { detail: { path: path, module: obj[path] }
-                    })
-                );
+                window.dispatchEvent(new CustomEvent(
+                    @moduleEvent,
+                    { detail: { path: path, module: obj[path] } }
+                ));
             }
         }
     }

--- a/src/templates/umd-standalone.txt
+++ b/src/templates/umd-standalone.txt
@@ -9,10 +9,10 @@
             return factory(root);
         });
     } else {
-        if (root.@name) {
-            root.@name.error(16, true);
+        if (root.@moduleSpace) {
+            root.@moduleSpace.error(16, true);
         }
-        root.@name = factory(root);
+        root.@moduleSpace = factory(root);
     }
 }(typeof window !== 'undefined' ? window : this, function (window) {
     'use strict';

--- a/src/templates/umd-standalone.txt
+++ b/src/templates/umd-standalone.txt
@@ -24,7 +24,7 @@
             if (typeof CustomEvent === 'function') {
                 window.dispatchEvent(
                     new CustomEvent(
-                        'HighchartsModuleLoaded',
+                        @moduleEvent,
                         { detail: { path: path, module: obj[path] }
                     })
                 );


### PR DESCRIPTION
- Added new option `namespace` independent of `product` option (Default: `Highcharts`)
- Added template tag `@moduleEvent`
- Fixed tag conflicts in templates by renaming `@name` to `@moduleSpace`