### PR TITLE
bugfix/20129-no-root-fails

### DIFF
--- a/src/templates/umd-standalone.txt
+++ b/src/templates/umd-standalone.txt
@@ -1,7 +1,7 @@
 (function (root, factory) {
     if (typeof module === 'object' && module.exports) {
         factory['default'] = factory;
-        module.exports = root.document ?
+        module.exports = (root && root.document) ?
             factory(root) :
             factory;
     } else if (typeof define === 'function' && define.amd) {


### PR DESCRIPTION
Fixed highcharts/highcharts#20129, failing error was thrown when the root was undefined.