### PR TITLE
bugfix/no-window-object-in-newer-node

### DIFF
--- a/src/templates/umd-standalone.txt
+++ b/src/templates/umd-standalone.txt
@@ -21,7 +21,7 @@
         if (!obj.hasOwnProperty(path)) {
             obj[path] = fn.apply(null, args);
 
-            if (typeof CustomEvent === 'function') {
+            if (window && typeof CustomEvent === 'function') {
                 window.dispatchEvent(new CustomEvent(
                     @moduleEvent,
                     { detail: { path: path, module: obj[path] } }


### PR DESCRIPTION
Fixed newer node had window as undefined when attempting dispatchEvent 